### PR TITLE
address a11y and seo issues

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,9 @@
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
   <!-- Enable responsiveness on mobile devices-->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   {% assign description = page.description | default: site.description %}
+  <meta name="description" content="{{ description }}">
 
   <title>
     {% if page.title == "Home" %}


### PR DESCRIPTION
- maximux-scale attribute less than 5 is an a11y issue
https://dequeuniversity.com/rules/axe/4.1/meta-viewport-large

- no meta description affects SEO as well as screen-readers